### PR TITLE
Removed index_t typedef as it conflicted with a system definition

### DIFF
--- a/src/common/alignment.h
+++ b/src/common/alignment.h
@@ -267,9 +267,9 @@ inline int M5RecordOvlpSize(const M5Record& m)
 
 //struct Overlap
 //{
-//    index_t qid, qoff, qend, qsize, qext;
+//    idx_t qid, qoff, qend, qsize, qext;
 //    int qdir;
-//    index_t sid, soff, send, ssize, sext;
+//    idx_t sid, soff, send, ssize, sext;
 //    int sdir;
 //};
 

--- a/src/common/defs.h
+++ b/src/common/defs.h
@@ -19,7 +19,6 @@ typedef uint64_t    u8_t;
 typedef i8_t        idx_t;
 
 typedef u1_t		uint1;
-typedef idx_t		index_t;
 
 #define INVALID_IDX (-1)
 

--- a/src/common/packed_db.h
+++ b/src/common/packed_db.h
@@ -26,15 +26,15 @@ public:
 		safe_calloc(pac, u1_t, bytes);
 	}
 	
-	void GetSequence(const index_t id, const bool fwd, char* seq, const index_t size_in_ovlp)
+	void GetSequence(const idx_t id, const bool fwd, char* seq, const idx_t size_in_ovlp)
 	{
-		const index_t offset = seq_idx[id].offset;
-		const index_t size = seq_idx[id].size;
+		const idx_t offset = seq_idx[id].offset;
+		const idx_t size = seq_idx[id].size;
 		r_assert(size == size_in_ovlp);
-		index_t idx = 0;
+		idx_t idx = 0;
 		if (fwd)
 		{
-			for (index_t i = 0; i < size; ++i)
+			for (idx_t i = 0; i < size; ++i)
 			{
 				uint1 c = get_char(offset + i);
 				seq[idx++] = c;
@@ -42,7 +42,7 @@ public:
 		}
 		else
 		{
-			for (index_t i = size - 1; i >= 0; --i)
+			for (idx_t i = size - 1; i >= 0; --i)
 			{
 				uint1 c = get_char(offset + i);
 				c = 3 - c;

--- a/src/filter_reads/filter_reads.cpp
+++ b/src/filter_reads/filter_reads.cpp
@@ -6,8 +6,6 @@
 
 using namespace std;
 
-typedef index_t idx;
-
 void print_usage(const char* prog)
 {
 	const char sep = ' ';
@@ -19,27 +17,27 @@ void print_usage(const char* prog)
 		 << "max-length" << endl;
 }
 
-idx parse_int(const char* arg)
+idx_t parse_int(const char* arg)
 {
 	istringstream in(arg);
-	idx n;
+	idx_t n;
 	in >> n;
 	if (!in) ERROR("failed to transfer '%s' to integer.", arg);
 	return n;
 }
 
 void
-output_one_read(Sequence& read, int& id, const idx min_size, const idx max_size, ostream& out)
+output_one_read(Sequence& read, int& id, const idx_t min_size, const idx_t max_size, ostream& out)
 {
-	idx n = read.size();
-	idx l = 0, r, left = n;
+	idx_t n = read.size();
+	idx_t l = 0, r, left = n;
 	Sequence::str_t& seq = read.sequence();
 	while (left) {
 		r = min(n, l + max_size);
-		idx s = r - l;
+		idx_t s = r - l;
 		if (s < min_size) break;
 		out << ">" << id++ << "\n";
-		for (idx i = l; i < r; ++i) {
+		for (idx_t i = l; i < r; ++i) {
 			out << seq[i];
 		}
 		out << "\n";
@@ -56,8 +54,8 @@ int main(int argc, char* argv[])
 	}
 	const char* input = argv[1];
 	const char* output = argv[2];
-	const idx min_size = parse_int(argv[3]);
-	const idx max_size = parse_int(argv[4]);
+	const idx_t min_size = parse_int(argv[3]);
+	const idx_t max_size = parse_int(argv[4]);
 	
 	FastaReader reader(input);
 	Sequence read;
@@ -65,7 +63,7 @@ int main(int argc, char* argv[])
 	open_fstream(out, output, ios::out);
 	int id = 0;
 	while (1) {
-		idx s = reader.read_one_seq(read);
+		idx_t s = reader.read_one_seq(read);
 		if (s == -1) break;
 		output_one_read(read, id, min_size, max_size, out);
 	}

--- a/src/mecat2cns/argument.h
+++ b/src/mecat2cns/argument.h
@@ -20,13 +20,13 @@ protected:
 class IntegerArgument : public Argument
 {
 public:
-    IntegerArgument(const std::string* an, const std::string* ad, const index_t v) : Argument(an, ad), val(v) {}
+    IntegerArgument(const std::string* an, const std::string* ad, const idx_t v) : Argument(an, ad), val(v) {}
     virtual ~IntegerArgument() {}
     virtual int ProcessArgument(int argc, char** argv);
-    index_t value() { return val; }
+    idx_t value() { return val; }
 
 private:
-    index_t val;
+    idx_t val;
 };
 
 class DoubleArgument : public Argument

--- a/src/mecat2cns/mecat_correction.cpp
+++ b/src/mecat2cns/mecat_correction.cpp
@@ -27,18 +27,18 @@ struct CompareOverlapByOverlapSize
 {
 	bool operator()(const Overlap& a ,const Overlap& b)
 	{
-		const index_t ovlp_a = std::max(a.qend - a.qoff, a.send - a.soff);
-		const index_t ovlp_b = std::max(b.qend - b.qoff, b.send - b.soff);
+		const idx_t ovlp_a = std::max(a.qend - a.qoff, a.send - a.soff);
+		const idx_t ovlp_b = std::max(b.qend - b.qoff, b.send - b.soff);
 		return ovlp_a > ovlp_b;
 	}
 };
 
 void
-meap_add_one_aln(const std::string& qaln, const std::string& saln, index_t start_soff, CnsTableItem* cns_table, const char* org_seq)
+meap_add_one_aln(const std::string& qaln, const std::string& saln, idx_t start_soff, CnsTableItem* cns_table, const char* org_seq)
 {
 	r_assert(qaln.size() == saln.size());
-	const index_t aln_size = qaln.size();
-	index_t i = 0;
+	const idx_t aln_size = qaln.size();
+	idx_t i = 0;
 	const char kGap = '-';
 	while (i < aln_size)
 	{
@@ -51,7 +51,7 @@ meap_add_one_aln(const std::string& qaln, const std::string& saln, index_t start
 		else
 		{
 			r_assert(s == kGap);
-			index_t j = i + 1;
+			idx_t j = i + 1;
 			while (j < aln_size && saln[j] == kGap) ++j;
 			++cns_table[start_soff - 1].del_cnt;
 			i = j;
@@ -155,8 +155,8 @@ get_effective_ranges(std::vector<MappingRange>& mranges, std::vector<MappingRang
 void
 output_cns_result(std::vector<CnsResult>& cns_results,
 				  CnsResult& cr,
-				  const index_t beg,
-				  const index_t end,
+				  const idx_t beg,
+				  const idx_t end,
 				  std::string& cns_seq) 
 {
 	const size_t MaxSeqSize = 60000;
@@ -214,7 +214,7 @@ consensus_worker(CnsTableItem* cns_table,
 				 const int read_id,
 				 std::vector<CnsResult>& cns_results)
 {
-	index_t beg = 0, end;
+	idx_t beg = 0, end;
 	CnsResult cns_result;
 	std::string cns_seq;
 	cns_result.id = read_id;
@@ -242,7 +242,7 @@ consensus_worker(CnsTableItem* cns_table,
 }
 
 void
-consensus_one_read_m4_pacbio(ConsensusThreadData* ctd, const index_t read_id, const index_t sid, const index_t eid)
+consensus_one_read_m4_pacbio(ConsensusThreadData* ctd, const idx_t read_id, const idx_t sid, const idx_t eid)
 {
 	PackedDB& reads = *ctd->reads;
 	ExtensionCandidate* overlaps = ctd->candidates;
@@ -251,7 +251,7 @@ consensus_one_read_m4_pacbio(ConsensusThreadData* ctd, const index_t read_id, co
 	M5Record* m5 = ctd->m5;
 	CnsAlns& cns_vec = ctd->cns_alns;
 	std::vector<CnsResult>& cns_results = ctd->cns_results;
-	const index_t read_size = overlaps[sid].ssize;
+	const idx_t read_size = overlaps[sid].ssize;
 	std::vector<char>& qstr = ctd->query;
 	std::vector<char>& tstr = ctd->target;
 	tstr.resize(read_size);
@@ -261,7 +261,7 @@ consensus_one_read_m4_pacbio(ConsensusThreadData* ctd, const index_t read_id, co
 	const int min_align_size = ctd->rco.min_align_size;
 	const int max_added = 60;
 
-	index_t L, R;
+	idx_t L, R;
 	if (eid - sid <= max_added)
 	{
 		L = sid;
@@ -277,13 +277,13 @@ consensus_one_read_m4_pacbio(ConsensusThreadData* ctd, const index_t read_id, co
 	CnsTableItem* cns_table = ctd->cns_table;
 	std::for_each(cns_table, cns_table + read_size, CnsTableItemCleaner());
 	cns_vec.clear();
-	for (index_t i = L; i < R; ++i)
+	for (idx_t i = L; i < R; ++i)
 	{
 		Overlap& ovlp = overlaps[i];
 		qstr.resize(ovlp.qsize);
 		reads.GetSequence(ovlp.qid, ovlp.qdir == FWD, qstr.data(), ovlp.qsize);
-		index_t qext = ovlp.qext;
-		index_t sext = ovlp.sext;
+		idx_t qext = ovlp.qext;
+		idx_t sext = ovlp.sext;
 		if (ovlp.qdir == REV) qext = ovlp.qsize - 1 - qext;
 		drd = drd_s;
 		bool r = GetAlignment(qstr.data(), qext, qstr.size(), tstr.data(), sext, tstr.size(), drd, *m5, 0.15, min_align_size);
@@ -303,7 +303,7 @@ consensus_one_read_m4_pacbio(ConsensusThreadData* ctd, const index_t read_id, co
 }
 
 void
-consensus_one_read_m4_nanopore(ConsensusThreadData* ctd, const index_t read_id, const index_t sid, const index_t eid)
+consensus_one_read_m4_nanopore(ConsensusThreadData* ctd, const idx_t read_id, const idx_t sid, const idx_t eid)
 {
 	PackedDB& reads = *ctd->reads;
 	ExtensionCandidate* overlaps = ctd->candidates;
@@ -312,7 +312,7 @@ consensus_one_read_m4_nanopore(ConsensusThreadData* ctd, const index_t read_id, 
 	M5Record* m5 = ctd->m5;
 	CnsAlns& cns_vec = ctd->cns_alns;
 	std::vector<CnsResult>& cns_results = ctd->cns_results;
-	const index_t read_size = overlaps[sid].ssize;
+	const idx_t read_size = overlaps[sid].ssize;
 	std::vector<char>& qstr = ctd->query;
 	std::vector<char>& tstr = ctd->target;
 	tstr.resize(read_size);
@@ -322,7 +322,7 @@ consensus_one_read_m4_nanopore(ConsensusThreadData* ctd, const index_t read_id, 
 	const int min_align_size = ctd->rco.min_align_size;
 	const double min_mapping_ratio = ctd->rco.min_mapping_ratio - 0.02;
 
-	index_t L, R;
+	idx_t L, R;
 	if (eid - sid <= MAX_CNS_OVLPS)
 	{
 		L = sid;
@@ -338,13 +338,13 @@ consensus_one_read_m4_nanopore(ConsensusThreadData* ctd, const index_t read_id, 
 	CnsTableItem* cns_table = ctd->cns_table;
 	std::for_each(cns_table, cns_table + read_size, CnsTableItemCleaner());
 	cns_vec.clear();
-	for (index_t i = L; i < R; ++i)
+	for (idx_t i = L; i < R; ++i)
 	{
 		Overlap& ovlp = overlaps[i];
 		qstr.resize(ovlp.qsize);
 		reads.GetSequence(ovlp.qid, ovlp.qdir == FWD, qstr.data(), ovlp.qsize);
-		index_t qext = ovlp.qext;
-		index_t sext = ovlp.sext;
+		idx_t qext = ovlp.qext;
+		idx_t sext = ovlp.sext;
 		if (ovlp.qdir == REV) qext = ovlp.qsize - 1 - qext;
 		drd = drd_s;
 		bool r = GetAlignment(qstr.data(), qext, qstr.size(), tstr.data(), sext, tstr.size(), drd, *m5, 0.20, min_align_size);
@@ -389,7 +389,7 @@ check_cov_stats(u1_t* cov_stats, int soff, int send)
 }
 
 void
-consensus_one_read_can_pacbio(ConsensusThreadData* ctd, const index_t read_id, const index_t sid, const index_t eid)
+consensus_one_read_can_pacbio(ConsensusThreadData* ctd, const idx_t read_id, const idx_t sid, const idx_t eid)
 {
 	PackedDB& reads = *ctd->reads;
 	ExtensionCandidate* candidates = ctd->candidates;
@@ -398,7 +398,7 @@ consensus_one_read_can_pacbio(ConsensusThreadData* ctd, const index_t read_id, c
 	M5Record* m5 = ctd->m5;
 	CnsAlns& cns_vec = ctd->cns_alns;
 	std::vector<CnsResult>& cns_results = ctd->cns_results;
-	const index_t read_size = candidates[sid].ssize;
+	const idx_t read_size = candidates[sid].ssize;
 	std::vector<char>& qstr = ctd->query;
 	std::vector<char>& tstr = ctd->target;
 	tstr.resize(read_size);
@@ -427,8 +427,8 @@ consensus_one_read_can_pacbio(ConsensusThreadData* ctd, const index_t read_id, c
 		if (used_ids.find(ec.qid) != used_ids.end()) continue;
 		qstr.resize(ec.qsize);
 		reads.GetSequence(ec.qid, ec.qdir == FWD, qstr.data(), ec.qsize);
-		index_t qext = ec.qext;
-		index_t sext = ec.sext;
+		idx_t qext = ec.qext;
+		idx_t sext = ec.sext;
 		if (ec.qdir == REV) qext = ec.qsize - 1 - qext;
 		drd = drd_s;
 		bool r = GetAlignment(qstr.data(), qext, qstr.size(), tstr.data(), sext, tstr.size(), drd, *m5, 0.15, min_align_size);
@@ -453,7 +453,7 @@ consensus_one_read_can_pacbio(ConsensusThreadData* ctd, const index_t read_id, c
 }
 
 void
-consensus_one_read_can_nanopore(ConsensusThreadData* ctd, const index_t read_id, const index_t sid, const index_t eid)
+consensus_one_read_can_nanopore(ConsensusThreadData* ctd, const idx_t read_id, const idx_t sid, const idx_t eid)
 {
 	PackedDB& reads = *ctd->reads;
 	ExtensionCandidate* candidates = ctd->candidates;
@@ -462,7 +462,7 @@ consensus_one_read_can_nanopore(ConsensusThreadData* ctd, const index_t read_id,
 	M5Record* m5 = ctd->m5;
 	CnsAlns& cns_vec = ctd->cns_alns;
 	std::vector<CnsResult>& cns_results = ctd->cns_results;
-	const index_t read_size = candidates[sid].ssize;
+	const idx_t read_size = candidates[sid].ssize;
 	std::vector<char>& qstr = ctd->query;
 	std::vector<char>& tstr = ctd->target;
 	tstr.resize(read_size);
@@ -490,8 +490,8 @@ consensus_one_read_can_nanopore(ConsensusThreadData* ctd, const index_t read_id,
 		if (used_ids.find(ec.qid) != used_ids.end()) continue;
 		qstr.resize(ec.qsize);
 		reads.GetSequence(ec.qid, ec.qdir == FWD, qstr.data(), ec.qsize);
-		index_t qext = ec.qext;
-		index_t sext = ec.sext;
+		idx_t qext = ec.qext;
+		idx_t sext = ec.sext;
 		if (ec.qdir == REV) qext = ec.qsize - 1 - qext;
 		drd = drd_s;
 		bool r = GetAlignment(qstr.data(), qext, qstr.size(), tstr.data(), sext, tstr.size(), drd, *m5, 0.20, min_align_size);

--- a/src/mecat2cns/mecat_correction.h
+++ b/src/mecat2cns/mecat_correction.h
@@ -6,16 +6,16 @@
 namespace ns_meap_cns {
 
 void
-consensus_one_read_m4_pacbio(ConsensusThreadData* ctd, const index_t read_id, const index_t sid, const index_t eid);
+consensus_one_read_m4_pacbio(ConsensusThreadData* ctd, const idx_t read_id, const idx_t sid, const idx_t eid);
 
 void
-consensus_one_read_m4_nanopore(ConsensusThreadData* ctd, const index_t read_id, const index_t sid, const index_t eid);
+consensus_one_read_m4_nanopore(ConsensusThreadData* ctd, const idx_t read_id, const idx_t sid, const idx_t eid);
 
 void
-consensus_one_read_can_pacbio(ConsensusThreadData* ctd, const index_t read_id, const index_t sid, const index_t eid);
+consensus_one_read_can_pacbio(ConsensusThreadData* ctd, const idx_t read_id, const idx_t sid, const idx_t eid);
 
 void
-consensus_one_read_can_nanopore(ConsensusThreadData* ctd, const index_t read_id, const index_t sid, const index_t eid);
+consensus_one_read_can_nanopore(ConsensusThreadData* ctd, const idx_t read_id, const idx_t sid, const idx_t eid);
 
 } // namespace ns_meap_cns
 

--- a/src/mecat2cns/options.cpp
+++ b/src/mecat2cns/options.cpp
@@ -9,7 +9,7 @@ using namespace std;
 
 static int input_type_pacbio 		= 1;
 static int num_threads_pacbio		= 1;
-static index_t batch_size_pacbio	= 100000;
+static idx_t batch_size_pacbio		= 100000;
 static double mapping_ratio_pacbio  = 0.9;
 static int align_size_pacbio		= 2000;
 static int cov_pacbio				= 6;
@@ -19,7 +19,7 @@ static int tech_pacbio				= TECH_PACBIO;
 
 static int input_type_nanopore 		    = 1;
 static int num_threads_nanopore		    = 1;
-static index_t batch_size_nanopore	    = 100000;
+static idx_t batch_size_nanopore	    = 100000;
 static double mapping_ratio_nanopore    = 0.4;
 static int align_size_nanopore		    = 400;
 static int cov_nanopore				    = 6;

--- a/src/mecat2cns/options.h
+++ b/src/mecat2cns/options.h
@@ -13,11 +13,11 @@ struct ConsensusOptions
     const char* reads;
     const char* corrected_reads;
     int         num_threads;
-    index_t     batch_size;
+    idx_t       batch_size;
     double      min_mapping_ratio;
     int         min_align_size;
     int         min_cov;
-    index_t     min_size;
+    idx_t       min_size;
     bool        print_usage_info;
     int         tech;
 };

--- a/src/mecat2cns/overlaps_partition.h
+++ b/src/mecat2cns/overlaps_partition.h
@@ -9,10 +9,10 @@ void
 generate_partition_index_file_name(const char* m4_file_name, std::string& ret);
 
 void
-generate_partition_file_name(const char* m4_file_name, const index_t part, std::string& ret);
+generate_partition_file_name(const char* m4_file_name, const idx_t part, std::string& ret);
 
 void
-partition_m4records(const char* m4_file_name, const double min_cov_ratio, const index_t batch_size, const int min_read_size);
+partition_m4records(const char* m4_file_name, const double min_cov_ratio, const idx_t batch_size, const int min_read_size);
 
 void
 partition_candidates(const char* input, const idx_t batch_size, const int min_read_size);
@@ -20,8 +20,8 @@ partition_candidates(const char* input, const idx_t batch_size, const int min_re
 struct PartitionFileInfo
 {
     std::string file_name;
-    index_t min_seq_id;
-    index_t max_seq_id;
+    idx_t min_seq_id;
+    idx_t max_seq_id;
 };
 
 void

--- a/src/mecat2cns/overlaps_store.h
+++ b/src/mecat2cns/overlaps_store.h
@@ -35,8 +35,8 @@ public:
         {
             fng(prefix.data(), i + sfid, file_names[i]);
             open_fstream(files[i], file_names[i].c_str(), std::ios::binary);
-            min_seq_ids[i] = std::numeric_limits<index_t>::max();
-            max_seq_ids[i] = std::numeric_limits<index_t>::min();
+            min_seq_ids[i] = std::numeric_limits<idx_t>::max();
+            max_seq_ids[i] = std::numeric_limits<idx_t>::min();
 			results[i].clear();
         }
         num_open_files = nf;

--- a/src/mecat2cns/reads_correction_aux.cpp
+++ b/src/mecat2cns/reads_correction_aux.cpp
@@ -1,6 +1,6 @@
 #include "reads_correction_aux.h"
 
-void normalize_gaps(const char* qstr, const char* tstr, const index_t aln_size, std::string& qnorm, std::string& tnorm, const bool push)
+void normalize_gaps(const char* qstr, const char* tstr, const idx_t aln_size, std::string& qnorm, std::string& tnorm, const bool push)
 {
     qnorm.clear();
     tnorm.clear();
@@ -8,7 +8,7 @@ void normalize_gaps(const char* qstr, const char* tstr, const index_t aln_size, 
 
 #ifndef NDEBUG
     int qcnt = 0, tcnt = 0;
-    for (index_t i = 0; i < aln_size; ++i)
+    for (idx_t i = 0; i < aln_size; ++i)
     {
         const char qc = qstr[i];
         const char tc = tstr[i];
@@ -18,7 +18,7 @@ void normalize_gaps(const char* qstr, const char* tstr, const index_t aln_size, 
 #endif
 
     // convert mismatches to indels
-    for (index_t i = 0; i < aln_size; ++i)
+    for (idx_t i = 0; i < aln_size; ++i)
     {
         const char qc = qstr[i];
         const char tc = tstr[i];
@@ -31,14 +31,14 @@ void normalize_gaps(const char* qstr, const char* tstr, const index_t aln_size, 
     // push gaps to the right, but not pass the end
     if (push)
     {
-        index_t qlen = qnorm.size();
-        index_t tlen = tnorm.size();
-        for (index_t i = 0; i < qlen - 1; ++i)
+        idx_t qlen = qnorm.size();
+        idx_t tlen = tnorm.size();
+        for (idx_t i = 0; i < qlen - 1; ++i)
         {
             // push target gaps
             if (tnorm[i] == kGap)
             {
-                index_t j = i;
+                idx_t j = i;
                 while (1)
                 {
                     const char c = tnorm[++j];
@@ -52,7 +52,7 @@ void normalize_gaps(const char* qstr, const char* tstr, const index_t aln_size, 
             // push query gaps
             if (qnorm[i] == kGap)
             {
-                index_t j = i;
+                idx_t j = i;
                 while (1)
                 {
                     const char c = qnorm[++j];
@@ -96,9 +96,9 @@ build_cns_thrd_data_can(ExtensionCandidate* ec_list,
 						std::ostream* out,
 					    ConsensusThreadData** ppctd)
 {
-	const index_t num_reads = max_rid - min_rid + 1;
+	const idx_t num_reads = max_rid - min_rid + 1;
 	const int num_threads = prco->num_threads;
-    const index_t num_reads_per_thread = (num_reads + num_threads - 1) / num_threads;
+    const idx_t num_reads_per_thread = (num_reads + num_threads - 1) / num_threads;
 	std::sort(ec_list, ec_list + nec, CmpExtensionCandidateBySid());
 	idx_t max_id = min_rid;
 	idx_t i = 0, j;

--- a/src/mecat2cns/reads_correction_aux.h
+++ b/src/mecat2cns/reads_correction_aux.h
@@ -162,7 +162,7 @@ struct ConsensusThreadData
 	}
 };
 
-void normalize_gaps(const char* qstr, const char* tstr, const index_t aln_size, std::string& qnorm, std::string& tnorm, const bool push);
+void normalize_gaps(const char* qstr, const char* tstr, const idx_t aln_size, std::string& qnorm, std::string& tnorm, const bool push);
 
 void
 build_cns_thrd_data_can(ExtensionCandidate* ec_list, 

--- a/src/mecat2cns/reads_correction_can.cpp
+++ b/src/mecat2cns/reads_correction_can.cpp
@@ -22,11 +22,11 @@ reads_correction_func_can(void* arg)
 {
     ConsensusThreadData& cns_data = *static_cast<ConsensusThreadData*>(arg);
 	ExtensionCandidate* candidates = cns_data.candidates;
-	const index_t num_candidates = cns_data.num_candidates;
-    index_t i = 0, j;
+	const idx_t num_candidates = cns_data.num_candidates;
+    idx_t i = 0, j;
     while (i < num_candidates)
     {
-        const index_t sid = candidates[i].sid;
+        const idx_t sid = candidates[i].sid;
         j = i + 1;
         while (j < num_candidates && candidates[j].sid == sid) ++j;
         if (j - i < cns_data.rco.min_cov) { i = j; continue; }
@@ -55,8 +55,8 @@ reads_correction_func_can(void* arg)
 
 void
 consensus_one_partition_can(const char* m4_file_name,
-						const index_t min_read_id,
-						const index_t max_read_id,
+						const idx_t min_read_id,
+						const idx_t max_read_id,
 						ReadsCorrectionOptions& rco,
 						PackedDB& reads,
 						std::ostream& out)

--- a/src/mecat2cns/reads_correction_m4.cpp
+++ b/src/mecat2cns/reads_correction_m4.cpp
@@ -11,11 +11,11 @@ reads_correction_func_m4(void* arg)
 {
     ConsensusThreadData& cns_data = *static_cast<ConsensusThreadData*>(arg);
 	ExtensionCandidate* overlaps = cns_data.candidates;
-	const index_t num_ovlps = cns_data.num_candidates;
-    index_t i = 0, j;
+	const idx_t num_ovlps = cns_data.num_candidates;
+    idx_t i = 0, j;
     while (i < num_ovlps)
     {
-        const index_t sid = overlaps[i].sid;
+        const idx_t sid = overlaps[i].sid;
         j = i + 1;
         while (j < num_ovlps && overlaps[j].sid == sid) ++j;
         if (j - i < cns_data.rco.min_cov) { i = j; continue; }
@@ -44,8 +44,8 @@ reads_correction_func_m4(void* arg)
 
 void
 consensus_one_partition_m4(const char* m4_file_name,
-        const index_t min_read_id,
-        const index_t max_read_id,
+        const idx_t min_read_id,
+        const idx_t max_read_id,
         ReadsCorrectionOptions& rco,
         PackedDB& reads,
         std::ostream& out)


### PR DESCRIPTION
Solaris has an index_t in sys/types.h that's a short.  The MECAT version is a long.  I realize you might not care about solaris compilation, but here it is, as I ran across it while hunting down a bug and wanted to remove it as a possible source of problems.

The original typedef was from idx_t (which is itself a typedef) to index_t, and I've simply removed the typedef and replaced index_t with idx_t, except for one file that further typedef'd index_t to idx where I removed the extra typedef and replaced idx with idx_t.