### PR TITLE
mecat2cns init fix

### DIFF
--- a/src/mecat2cns/overlaps_partition.cpp
+++ b/src/mecat2cns/overlaps_partition.cpp
@@ -148,10 +148,14 @@ normalise_candidate(ExtensionCandidate& src, ExtensionCandidate& dst, const bool
 		dst.qid = src.sid;
 		dst.qext = src.sext;
 		dst.qsize = src.ssize;
+		dst.qoff = src.soff;
+		dst.qend = src.send;
 		dst.sdir = src.qdir;
 		dst.sid = src.qid;
 		dst.sext = src.qext;
 		dst.ssize = src.qsize;
+		dst.soff = src.qoff;
+		dst.send = src.qend;
 		dst.score = src.score;
 	}
 	
@@ -189,6 +193,8 @@ partition_candidates(const char* input, const idx_t batch_size, const int min_re
 		
 		while (in >> ec)
 		{
+			// not set by >>
+			ec.qoff = ec.soff = ec.qend = ec.send = 0;
 			if (ec.qsize < min_read_size || ec.ssize < min_read_size) continue;
 			if (ec.qid >= L && ec.qid < R)
 			{


### PR DESCRIPTION
ExtensionCandidate has four fields that are not set when read into from a stream, not when copied by normalize_candidate(), leading to random data being written out to files when those elements are written.  Perhaps not a problem, but it could be, and it makes debugging and comparison very tricky when files contain random data.

This fix does not change the stream reading directly, but rather only when called in one place in mecat2cns, just in case that particular behavoir is relied upon elsewhere (although I certainly hope not).