### PR TITLE
Fix typo

### DIFF
--- a/dextract_makefile
+++ b/dextract_makefile
@@ -7,7 +7,7 @@ dextract:
 	${CC} $(CFLAGS) -I$(HDF5_INCLUDE) -L$(HDF5_LIB) -o dextract dextract.c DB.c QV.c -lhdf5
 
 dexta: 
-	${CC} ${CFLAGS} -o dexta gdexta.c DB.c QV.c
+	${CC} ${CFLAGS} -o dexta dexta.c DB.c QV.c
 
 undexta: 
 	${CC} ${CFLAGS} -o undexta undexta.c DB.c QV.c


### PR DESCRIPTION
In DEXTRACTOR there is no `gdexta.c`, only `dexta.c`